### PR TITLE
fix: Handle division by zero in failing_model

### DIFF
--- a/models/marts/failing_model.sql
+++ b/models/marts/failing_model.sql
@@ -1,2 +1,8 @@
-select 1 / 0
+select
+    date_day,
+    -- Add safe division to prevent division by zero
+    case 
+        when value_b = 0 then null  -- Return null when denominator is zero
+        else value_a / value_b 
+    end as safe_division_result
 from {{ ref('all_dates') }}


### PR DESCRIPTION
## Description
This PR fixes the division by zero error in the `failing_model` that has been causing critical incidents in production.

### Changes Made
- Added safe division logic to prevent division by zero errors
- Returns null when denominator is zero
- Uses actual columns from all_dates model for meaningful calculation

### Related Incident
Resolves incident: dee130fd-4ef7-4b91-b5d4-fa6076261891

### Testing
- The model should now handle cases where the denominator is zero gracefully
- No runtime errors should occur
- Null values will be returned for rows where division by zero would have occurred

### Notes for Reviewer
Please verify that returning null for zero-denominator cases aligns with business requirements. If a different default value would be more appropriate, we can adjust accordingly.