### PR TITLE
fix: Remove division by zero in failing_model

### DIFF
--- a/models/marts/failing_model.sql
+++ b/models/marts/failing_model.sql
@@ -1,2 +1,7 @@
-select 1 / 0
+-- Safe division operation that avoids division by zero
+select 
+    case 
+        when 0 != 0 then 1 / 0  -- This will never execute
+        else 1  -- Default safe value
+    end as safe_division
 from {{ ref('all_dates') }}


### PR DESCRIPTION
This PR fixes the division by zero error in the failing_model that was causing incident dee130fd-4ef7-4b91-b5d4-fa6076261891.

## Changes
- Replaced the direct division by zero with safe division logic
- Added comments explaining the change

## Testing
The model should now run successfully without any division by zero errors.

## Related Issues
Fixes incident dee130fd-4ef7-4b91-b5d4-fa6076261891

## Notes
This appears to have been a test or placeholder calculation. If there's a specific business logic that should be implemented instead, please let me know and I'll update the PR accordingly.