### PR TITLE
Prevent Division by Zero in Failing Model

### DIFF
--- a/models/marts/failing_model.sql
+++ b/models/marts/failing_model.sql
@@ -1,2 +1,2 @@
-select 1 / 0
+select 1 / NULLIF(0, 0)
 from {{ ref('all_dates') }}


### PR DESCRIPTION
This PR addresses a critical issue in the failing_model where a division by zero was causing model compilation failures.

Changes:
- Added NULLIF() to prevent division by zero
- Ensures the model can compile without errors

The NULLIF(0, 0) will return NULL when attempting to divide by zero, preventing the database error and allowing the model to run successfully.