### PR TITLE
Convert py_all_dates model to SQL

### DIFF
--- a/models/marts/py_all_dates.sql
+++ b/models/marts/py_all_dates.sql
@@ -1,0 +1,5 @@
+with all_dates as (
+    select * from {{ ref('all_dates') }}
+)
+
+select * from all_dates


### PR DESCRIPTION
This PR converts the py_all_dates model from Python to SQL to resolve the runtime error. The model now depends on the all_dates model and selects all columns from it.