### PR TITLE
Convert py_all_dates model from Python to SQL

### DIFF
--- a/models/marts/py_all_dates.sql
+++ b/models/marts/py_all_dates.sql
@@ -1,0 +1,4 @@
+{{ config(materialized='table') }}
+
+SELECT *
+FROM {{ ref('all_dates') }}


### PR DESCRIPTION
This PR converts the py_all_dates model from Python to SQL to resolve the materialization error.

Changes made:
1. Renamed file from py_all_dates.py to py_all_dates.sql
2. Replaced Python code with equivalent SQL

This change should resolve the runtime error where the materialization method only supported SQL but encountered a Python model.

Please review and test this change to ensure it meets your requirements and resolves the issue.