### PR TITLE
Elementary: Convert py_all_dates model from Python to SQL

### DIFF
--- a/models/marts/py_all_dates.py
+++ b/models/marts/py_all_dates.py
@@ -1,3 +1,0 @@
-def model(dbt, session):
-    df = dbt.ref("all_dates")
-    return df

--- a/models/marts/py_all_dates.sql
+++ b/models/marts/py_all_dates.sql
@@ -1,0 +1,2 @@
+SELECT *
+FROM {{ ref('all_dates') }}


### PR DESCRIPTION
This PR addresses the incident (ID: ce5c317c-9951-46b1-9571-8edd8b087e16) where the py_all_dates model was failing due to a mismatch between the Python code and the table materialization.

Changes made:
1. Converted the Python model to an equivalent SQL model
2. Renamed the file from py_all_dates.py to py_all_dates.sql
3. Kept the model name as 'py_all_dates' as requested

The new SQL model performs the same function as the previous Python model, selecting all columns from the 'all_dates' model without any additional transformations.

This change should resolve the materialization error and allow the model to compile and run successfully.

Please review and test this change to ensure it meets your requirements and resolves the incident.