### PR TITLE
Ofek Weiss via Elementary: Fix division by zero error in failing_model

### DIFF
--- a/models/marts/failing_model.sql
+++ b/models/marts/failing_model.sql
@@ -1,2 +1,5 @@
-select 1 / 0
+-- models/marts/failing_model.sql
+select 
+    date_day,
+    1 / NULLIF(day_of_month, 0) as inverse_day_of_month
 from {{ ref('all_dates') }}


### PR DESCRIPTION
This PR addresses the critical incident related to the `failing_model`. 

Changes made:
1. Replaced the division by zero operation with a safe division using NULLIF.
2. Added a meaningful calculation (inverse of day of month) instead of the placeholder division.

This change should resolve the database error and allow the model to run successfully. The new query selects the `date_day` from the `all_dates` model and calculates the inverse of the day of the month, handling potential division by zero cases.

Please review and test this change to ensure it meets the requirements for the `failing_model`.

Closes #[Insert issue number if applicable]<br><br>Created by: `ofek@elementary-data.com`