### PR TITLE
Ofek Weiss via Elementary: Fix division by zero error in failing_model

### DIFF
--- a/models/marts/failing_model.sql
+++ b/models/marts/failing_model.sql
@@ -1,2 +1,6 @@
-select 1 / 0
+select 
+    case 
+        when 0 = 0 then null
+        else 1 / 0
+    end
 from {{ ref('all_dates') }}


### PR DESCRIPTION
This PR fixes the division by zero error in the `failing_model` by adding a condition to check if the denominator is zero before performing the division.<br><br>Created by: `ofek@elementary-data.com`