### PR TITLE
Ofek Weiss via Elementary: Fix division by zero error in failing_model

### DIFF
--- a/models/marts/failing_model.sql
+++ b/models/marts/failing_model.sql
@@ -1,2 +1,3 @@
-select 1 / 0
+select *
 from {{ ref('all_dates') }}
+limit 1


### PR DESCRIPTION
This PR fixes the division by zero error in the failing_model.sql file.

Changes made:
- Replaced the query `select 1 / 0` with `select * from {{ ref('all_dates') }} limit 1`

This change removes the division by zero error and instead selects a single row from the all_dates table. This is a temporary fix to make the model run without errors. 

Next steps:
1. Review the intended purpose of this model
2. Update the query to properly reflect the model's requirements
3. Add appropriate tests to prevent similar issues in the future

Please review and provide feedback on any additional changes needed.<br><br>Created by: `ofek@elementary-data.com`