### PR TITLE
Ofek Weiss via Elementary: Fix failing_model SQL to prevent division by zero error

### DIFF
--- a/models/marts/failing_model.sql
+++ b/models/marts/failing_model.sql
@@ -1,2 +1,6 @@
-select 1 / 0
+select
+    date_day,
+    extract(year from date_day) as year,
+    extract(month from date_day) as month,
+    extract(day from date_day) as day
 from {{ ref('all_dates') }}


### PR DESCRIPTION
This PR fixes the `failing_model` which was causing a critical incident due to a division by zero error.

Changes:
- Removed the invalid `select 1 / 0` query
- Replaced it with a valid query that extracts date components from the `all_dates` model

This fix should resolve the current incident and allow the model to run successfully.<br><br>Created by: `ofek@elementary-data.com`