### PR TITLE
Ofek Weiss via Elementary: Fix division by zero error in failing_model

### DIFF
--- a/models/marts/failing_model.sql
+++ b/models/marts/failing_model.sql
@@ -1,2 +1,4 @@
-select 1 / 0
+-- Safe calculation that doesn't divide by zero
+select 
+  1 as safe_calculation
 from {{ ref('all_dates') }}


### PR DESCRIPTION
## Description
This PR fixes the critical incident in the `failing_model` by removing the division by zero operation that was causing the model to fail.

## Changes
- Replaced `select 1 / 0` with `select 1 as safe_calculation`
- The model now produces a simple output with a constant value that will execute successfully

## Related Incident
This fixes incident ID: a7857ac1-c0aa-455b-8f25-9bd7d4bf3a35

## Testing
The model should now run successfully without the division by zero error.<br><br>Created by: `ofek@elementary-data.com`