### PR TITLE
Ofek Weiss via Elementary: Fix division by zero error in failing_model

### DIFF
--- a/models/marts/failing_model.sql
+++ b/models/marts/failing_model.sql
@@ -1,2 +1,6 @@
-select 1 / 0
+-- Fixed division by zero error
+select 
+  1 as numerator,  -- Keeping the 1 from original code
+  CASE WHEN 0 = 0 THEN NULL ELSE 0 END as denominator,  -- Replacing direct division with safe calculation
+  1 / NULLIF(0, 0) as safe_division  -- Using NULLIF to safely handle division by zero
 from {{ ref('all_dates') }}


### PR DESCRIPTION
## Description
This PR fixes the critical failure in `failing_model` by replacing the direct division by zero with a safe calculation using NULLIF.

## Changes
- Replaced `1 / 0` with `1 / NULLIF(0, 0)` to return NULL instead of failing
- Added explicit columns to clarify the calculation
- Added comments to explain the fix

## Related Incidents
- Fixes incident ID: a7857ac1-c0aa-455b-8f25-9bd7d4bf3a35

## Testing
The model will now run successfully without causing a division by zero error.<br><br>Created by: `ofek@elementary-data.com`