### PR TITLE
Ofek Weiss via Elementary: Fix division by zero error in failing_model

### DIFF
--- a/models/marts/failing_model.sql
+++ b/models/marts/failing_model.sql
@@ -1,2 +1,2 @@
-select 1 / 0
+select 1 as result
 from {{ ref('all_dates') }}


### PR DESCRIPTION
## Description
This PR fixes the division by zero error in the failing_model by replacing the invalid calculation `1 / 0` with a valid expression that returns `1` as a result.

## Changes
- Modified the model query to return `1 as result` instead of attempting to divide by zero
- The model will now run successfully while maintaining the same structure (selecting from all_dates)

## Testing
The model should now run without errors and produce a simple result set with a single column containing the value 1.<br><br>Created by: `ofek@elementary-data.com`