### PR TITLE
Ofek Weiss via Elementary: Fix division by zero error in failing_model

### DIFF
--- a/models/marts/failing_model.sql
+++ b/models/marts/failing_model.sql
@@ -1,2 +1,6 @@
-select 1 / 0
+select 
+  CASE 
+    WHEN 0 != 0 THEN 1 / 0
+    ELSE NULL  -- Return NULL instead of error
+  END
 from {{ ref('all_dates') }}

--- a/models/marts/failing_model.sql
+++ b/models/marts/failing_model.sql
@@ -3,4 +3,4 @@ select
     WHEN 0 != 0 THEN 1 / 0
     ELSE NULL  -- Return NULL instead of error
   END
-from {{ ref('all_dates') }}
+from {{ ref('all_dates') }} -- TODO: This reference should be reviewed and potentially changed


### PR DESCRIPTION
## Description
This PR fixes the division by zero error in the failing_model SQL. The model was attempting to perform `1 / 0` which causes a database error.

## Changes
- Replaced the direct division with a CASE statement that handles the zero denominator case
- Returns NULL instead of attempting the invalid division

## Testing
The model should now run without throwing the division by zero error.<br><br>Created by: `ofek@elementary-data.com`