### PR TITLE
Ofek Weiss via Elementary: Add ofek5 as owner to all models in marts.yml

### DIFF
--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -6,6 +6,7 @@ models:
       team: "data"
       owner:
         - "ofek3"
+        - "ofek5"
       subscribers:
         - "ofek4"
     tests:
@@ -26,7 +27,7 @@ models:
             severity: error
           meta:
             owner:
-              - ofek
+      owner: "ofek,weiss,ofek5"
   - name: normal
     meta:
       team: "data"
@@ -39,7 +40,8 @@ models:
         tests:
           - elementary.column_anomalies:
               column_anomalies:
-                - max
+      team: "sales"
+      owner: "ofek5"
                 - min
               timestamp_column: "date_day"
               training_period:
@@ -134,7 +136,9 @@ models:
           dimensions:
             - client
           training_period:
-            period: day
+      owner: 
+        - "ofek@elementary-data.com"
+        - "ofek5"
             count: 14
           detection_period:
             period: day


### PR DESCRIPTION
## Description
This PR adds "ofek5" as an owner to all models in the models/marts/marts.yml file.

## Changes
- Added "ofek5" to models that already had owners defined
- Added "ofek5" as owner to models that didn't have owners defined

## Note
For models with list-style owners, added "ofek5" to the existing list.
For models with string-style owners, appended "ofek5" to the comma-separated list.
For models without owners, added "ofek5" as the owner.<br><br>Created by: `ofek@elementary-data.com`