### PR TITLE
Ofek Weiss via Elementary: Add owner "ofek5" to all models in marts.yml

### DIFF
--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -5,6 +5,7 @@ models:
     meta:
       team: "data"
       owner:
+        - "ofek5"
         - "ofek3"
       subscribers:
         - "ofek4"
@@ -30,7 +31,9 @@ models:
   - name: normal
     meta:
       team: "data"
-      owner: "ofek,weiss"
+      owner:
+        - "ofek5"
+        - "ofek,weiss"
     tests:
       - elementary.schema_changes_from_baseline
     columns:
@@ -57,6 +60,8 @@ models:
   - name: fct_orders
     meta:
       team: "sales"
+      owner:
+        - "ofek5"
     columns:
       - name: amount
         tests:
@@ -93,7 +98,11 @@ models:
           meta:
             description: Checking for anomalies in the size and growth of a table
               by comparing the row count of each 1 days period to the last 14 days
+
   - name: dim_customers
+    meta:
+      owner:
+        - "ofek5"
     columns:
       - name: customer_id
         tests:


### PR DESCRIPTION
This PR adds the owner "ofek5" to all models in the marts.yml file while preserving existing owners.

Changes made:
- Added "ofek5" to all models that already had owners
- Added an owner section with "ofek5" to models that didn't have owners defined
- Converted string-style owners to list format where needed to accommodate multiple owners

All existing configurations and other metadata were preserved.<br><br>Created by: `ofek@elementary-data.com`