### PR TITLE
Ofek Weiss via Elementary: Add owner ofek5 to all models in marts.yml

### DIFF
--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -6,6 +6,7 @@ models:
       team: "data"
       owner:
         - "ofek3"
+        - "ofek5"
       subscribers:
         - "ofek4"
     tests:
@@ -30,7 +31,7 @@ models:
   - name: normal
     meta:
       team: "data"
-      owner: "ofek,weiss"
+      owner: "ofek,weiss,ofek5"
     tests:
       - elementary.schema_changes_from_baseline
     columns:
@@ -57,6 +58,7 @@ models:
   - name: fct_orders
     meta:
       team: "sales"
+      owner: ["ofek5"]
     columns:
       - name: amount
         tests:
@@ -94,6 +96,8 @@ models:
             description: Checking for anomalies in the size and growth of a table
               by comparing the row count of each 1 days period to the last 14 days
   - name: dim_customers
+    meta:
+      owner: ["ofek5"]
     columns:
       - name: customer_id
         tests:
@@ -103,6 +107,8 @@ models:
               field: customer_id
               to: ref('stg_customers')
   - name: test_table
+    meta:
+      owner: ["ofek5"]
     tests:
       - elementary.freshness_anomalies:
           timestamp_column: data
@@ -112,6 +118,8 @@ models:
             period: day
             count: 1
   - name: dimension
+    meta:
+      owner: ["ofek5"]
     tests:
       - elementary.dimension_anomalies:
           timestamp_column: date
@@ -127,6 +135,8 @@ models:
             period: day
             count: 1
   - name: dimension_error
+    meta:
+      owner: ["ofek5"]
     tests:
       - elementary.dimension_anomalies:
           severity: warn
@@ -152,6 +162,8 @@ models:
           dimensions:
             - client
   - name: max_error
+    meta:
+      owner: ["ofek5"]
     tests:
       - elementary.column_anomalies:
           column_name: value
@@ -187,7 +199,7 @@ models:
             - client
   - name: failing_model
     meta:
-      owner: "ofek@elementary-data.com"
+      owner: ["ofek@elementary-data.com", "ofek5"]
       channel: "ofek-test2"
       subscribers:
         - "@Ofek Aharon Weiss"


### PR DESCRIPTION
This PR adds the owner "ofek5" to all models in the marts.yml file. 

Changes:
- Added "ofek5" to existing owner lists where present
- Created new owner lists with "ofek5" where no owners were previously defined
- Maintained all existing owners while adding the new one
- Different formatting approaches were preserved based on the existing structure (array vs string format)<br><br>Created by: `ofek@elementary-data.com`